### PR TITLE
Install clippy and rustup in nightly_lints

### DIFF
--- a/.github/workflows/nightly_lints.yml
+++ b/.github/workflows/nightly_lints.yml
@@ -22,6 +22,9 @@ jobs:
         with:
             toolchain: ${{ steps.component.outputs.toolchain }}
             override: true
+            
+      - name: Install clippy
+        run: rustup component add clippy
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
@@ -45,11 +48,14 @@ jobs:
           component: rustfmt
 
 
-      - name: Install nightly toolchain with clippy available
+      - name: Install nightly toolchain with rustfmt available
         uses: actions-rs/toolchain@v1
         with:
             toolchain: ${{ steps.component.outputs.toolchain }}
             override: true
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
In the nightly lints example the clippy and rustup components were not added like in the rest of the examples. This adds the installation so everything runs.